### PR TITLE
fix gui not responsive while re-packing

### DIFF
--- a/gui/Form1.Designer.cs
+++ b/gui/Form1.Designer.cs
@@ -122,6 +122,7 @@
 			outputDisplay.Multiline = true;
 			outputDisplay.Name = "outputDisplay";
 			outputDisplay.ReadOnly = true;
+			outputDisplay.ScrollBars = ScrollBars.Vertical;
 			outputDisplay.Size = new Size(432, 360);
 			outputDisplay.TabIndex = 2;
 			// 
@@ -154,6 +155,8 @@
 			// 
 			preferCompressedTextures.Anchor = AnchorStyles.Bottom | AnchorStyles.Left;
 			preferCompressedTextures.AutoSize = true;
+			preferCompressedTextures.Checked = true;
+			preferCompressedTextures.CheckState = CheckState.Checked;
 			preferCompressedTextures.Location = new Point(249, 452);
 			preferCompressedTextures.Margin = new Padding(4, 5, 4, 5);
 			preferCompressedTextures.Name = "preferCompressedTextures";


### PR DESCRIPTION
1. fix gui not responsive while re-packing
2. check 'compress textures' by default
3. add vertical scrollbar to message textbox
4. include 'total size reduced' information in messages